### PR TITLE
fix: исправление ошибки в Postman тесте "Review update to positive"

### DIFF
--- a/postman/sprint.json
+++ b/postman/sprint.json
@@ -7423,7 +7423,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"reviewId\": 1,\n  \"content\": \"This film is not too bad.\",\n  \"isPositive\": true,\n  \"userId\": 2,\n  \"filmId\": 2,\n  \"useful\": 10\n}",
+							"raw": "{\n  \"reviewId\": 1,\n  \"content\": \"This film is not too bad.\",\n  \"isPositive\": true,\n  \"userId\": 1,\n  \"filmId\": 1,\n  \"useful\": 10\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
В теле запроса передаются 
```
  "userId": 2,
  "filmId": 2,
```
В тесте проверяется что они равны 1 

```
pm.test("Test review 'userId' field", function () {
    var jsonData = pm.response.json();
    pm.expect(jsonData).to.have.property('userId');
    pm.expect(jsonData.userId, '"userId" field must be "1"').to.eql(1);
});
pm.test("Test review 'filmId' field", function () {
    var jsonData = pm.response.json();
    pm.expect(jsonData).to.have.property('filmId');
    pm.expect(jsonData.filmId, '"filmId" field must be "1"').to.eql(1);
});
```
